### PR TITLE
Build the app in the workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,21 +8,44 @@ on:
 jobs:
 
   build:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag vectara/vectara-answer:$(date +%s)
-
-  push_to_registry:
-    name: Push Docker image to Docker Hub
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-      
+
+      - name: Setup Node
+        uses: actions/setup-node@master
+
+      # Install applicaion dependencies
+      - name: Install dependencies
+        run: |
+          npm install
+
+      # Build the app
+      - name: Build app
+        run: |
+          npm run build
+          docker build . --file docker/Dockerfile --tag vectara/vectara-answer:$(date +%s)
+
+      - uses: actions/upload-artifact@master
+        with:
+          name: build_dir
+          path: build
+
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - uses: actions/download-artifact@master
+        with:
+          name: build_dir
+          path: build
+  
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
@@ -39,7 +62,7 @@ jobs:
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
           context: .
-          file: ./Dockerfile
+          file: ./docker/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
We've removed the `build/` dir from github, so we need to build it ourselves.

We decided we don't want to add `npm run build` inside the dockerfile.