### PR TITLE
Add toggle to hide/show summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ sources: "BBC,NPR,FOX,CNBC,CNN"
 The way summarization works can be configured as follows:
 
 ```yaml
-# Hide or show summary (if not specified defaults to True)
+# Hide or show summary (if not specified defaults to True). When set to False, it hides the summary and prevents the call to the summarization API.
 enable_summary: True
 
 # Default language for summary response (if not specified defaults to "auto")

--- a/README.md
+++ b/README.md
@@ -176,7 +176,10 @@ sources: "BBC,NPR,FOX,CNBC,CNN"
 The way summarization works can be configured as follows:
 
 ```yaml
-# Default language for summary response (if not specified defaults to "auto)
+# Hide or show summary (if not specified defaults to True)
+enable_summary: True
+
+# Default language for summary response (if not specified defaults to "auto")
 summary_default_language: "en"
 
 # Number of sentences before and after relevant text segment used for summarization

--- a/docker/server/index.js
+++ b/docker/server/index.js
@@ -35,6 +35,7 @@ app.post("/config", (req, res) => {
     sources,
 
     // summary
+    enable_summary,
     summary_default_language,
     summary_num_results,
     summary_num_sentences,
@@ -86,6 +87,7 @@ app.post("/config", (req, res) => {
     sources,
 
     // summary
+    enable_summary,
     summary_default_language,
     summary_num_results,
     summary_num_sentences,

--- a/server/index.js
+++ b/server/index.js
@@ -35,6 +35,7 @@ app.post("/config", (req, res) => {
     sources,
 
     // summary
+    enable_summary,
     summary_default_language,
     summary_num_results,
     summary_num_sentences,
@@ -86,6 +87,7 @@ app.post("/config", (req, res) => {
     sources,
 
     // summary
+    enable_summary,
     summary_default_language,
     summary_num_results,
     summary_num_sentences,

--- a/src/contexts/ConfigurationContext.tsx
+++ b/src/contexts/ConfigurationContext.tsx
@@ -54,6 +54,7 @@ interface Config {
   config_full_story_org_id?: string;
 
   // Summary
+  config_enable_summary?: string;
   config_summary_default_language?: string;
   config_summary_num_results?: number,
   config_summary_num_sentences?: number,
@@ -101,6 +102,7 @@ type Filters = {
 };
 
 type Summary = {
+  isEnabled: boolean;
   defaultLanguage: string;
   summaryNumResults: number;
   summaryNumSentences: number;
@@ -226,6 +228,7 @@ export const ConfigContextProvider = ({ children }: Props) => {
   const [rerank, setRerank] = useState<Rerank>({ isEnabled: false, numResults: 100 });
 
   const [summary, setSummary] = useState<Summary>({
+    isEnabled: true,
     defaultLanguage: "auto",
     summaryNumResults: 7,
     summaryNumSentences: 3,
@@ -311,6 +314,7 @@ export const ConfigContextProvider = ({ children }: Props) => {
         config_rerank_num_results,
 
         // Summary
+        config_enable_summary,
         config_summary_default_language,
         config_summary_num_results,
         config_summary_num_sentences,
@@ -370,6 +374,7 @@ export const ConfigContextProvider = ({ children }: Props) => {
       });
 
       setSummary({
+        isEnabled: isTrue(config_enable_summary ?? "True"),
         defaultLanguage: validateLanguage(config_summary_default_language as SummaryLanguage, "auto"),
         summaryNumResults: config_summary_num_results ?? 7,
         summaryNumSentences: config_summary_num_sentences ?? 3,

--- a/src/views/search/SearchView.tsx
+++ b/src/views/search/SearchView.tsx
@@ -25,6 +25,7 @@ export const SearchView = () => {
     isSearching,
     searchError,
     searchResults,
+    includeSummary,
     isSummarizing,
     summarizationError,
     summarizationResponse,
@@ -67,21 +68,21 @@ export const SearchView = () => {
       <>
         <VuiSpacer size="s" />
 
-        <Summary
-          isSummarizing={isSummarizing}
-          summarizationError={summarizationError}
-          summary={summary}
-          selectedSearchResultPosition={selectedSearchResultPosition}
-          onClickCitation={(position: number) =>
-            selectSearchResultAt(position - 1)
-          }
-        />
-
-        <VuiSpacer size="l" />
-
-        <VuiHorizontalRule />
-
-        <VuiSpacer size="l" />
+        {includeSummary && (
+          <>
+            <VuiSpacer size="s" />
+            <Summary
+              isSummarizing={isSummarizing}
+              summarizationError={summarizationError}
+              summary={summary}
+              selectedSearchResultPosition={selectedSearchResultPosition}
+              onClickCitation={(position: number) => selectSearchResultAt(position - 1)}
+            />
+            <VuiSpacer size="l" />
+            <VuiHorizontalRule />
+            <VuiSpacer size="l" />
+          </>
+        )}
 
         <SearchResults
           isSearching={isSearching}
@@ -91,6 +92,7 @@ export const SearchView = () => {
           setSearchResultRef={(el: HTMLDivElement | null, index: number) =>
             ((searchResultsRef as any).current[index] = el)
           }
+          includeSummary={includeSummary}
         />
       </>
     );

--- a/src/views/search/results/SearchResults.tsx
+++ b/src/views/search/results/SearchResults.tsx
@@ -12,6 +12,7 @@ import {
 import { SearchResultList } from "./SearchResultList";
 
 type Props = {
+  includeSummary: boolean;
   isSearching: boolean;
   searchError?: any;
   results?: DeserializedSearchResult[];
@@ -20,6 +21,7 @@ type Props = {
 };
 
 export const SearchResults = ({
+  includeSummary,
   isSearching,
   searchError,
   results,
@@ -73,11 +75,13 @@ export const SearchResults = ({
     );
   }
 
+  const searchHeaderText = includeSummary ? "References" : `${results?.length} Search Results`;
+
   return (
     <>
       <VuiTitle size="xxs">
         <h2>
-          <strong>References</strong>
+          <strong>{searchHeaderText}</strong>
         </h2>
       </VuiTitle>
 

--- a/src/views/search/results/SearchResults.tsx
+++ b/src/views/search/results/SearchResults.tsx
@@ -75,7 +75,7 @@ export const SearchResults = ({
     );
   }
 
-  const searchHeaderText = includeSummary ? "References" : `${results?.length} Search Results`;
+  const searchHeaderText = includeSummary ? "References" : "Search Results";
 
   return (
     <>


### PR DESCRIPTION
This PR adds the ability to hide or show the summary feature via the config.yaml file.

Example:
```
corpus_id: 1
customer_id:

search_title: "Ask Paul Graham"

enable_source_filters: False
source: ""

enable_summary: True
```

By default, the `enable_summary` value is set to `True`. 

When enable_summary is on, the search header text is set to "References." When it's off, the text is set to "num Search Results", where "num" is the number of search results displayed. However, I'm not sure if it's necessary to show the number of search results since it's always a fixed number.