### PR TITLE
Fix new line issue affecting search description

### DIFF
--- a/docker/prepare_config.py
+++ b/docker/prepare_config.py
@@ -2,7 +2,6 @@ import sys
 import yaml
 import os
 
-
 # Local implementation of simple TOML file read, to avoid requiring python toml package install
 def parse_section_line(line):
     return line.strip()[1:-1]
@@ -78,6 +77,8 @@ def main(config_folder, profile):
 
     with open(".env", "w") as f:
         for k in new_config.keys():
+            if type(new_config[k]) == str:
+                new_config[k] = new_config[k].replace("\n", "\\n")
             f.write(f"{k}={new_config[k]}\n")
 
 

--- a/src/views/search/controls/SearchControls.tsx
+++ b/src/views/search/controls/SearchControls.tsx
@@ -110,7 +110,9 @@ export const SearchControls = ({
               <VuiFlexItem grow={false}>
                 <VuiTitle size="xxs" align="right">
                   <VuiTextColor color="subdued">
-                    <h2>{searchHeader.description}</h2>
+                    <h2 style={{ whiteSpace: "pre-line" }}>
+                      {searchHeader.description.replaceAll("\\n", "\n")}
+                    </h2>
                   </VuiTextColor>
                 </VuiTitle>
               </VuiFlexItem>


### PR DESCRIPTION
If the search description includes a `\n`, the .env file becomes incorrectly formatted which results in the following error: `poorly formatted environment:`.

To fix this, I replaced all occurrences of `\n` with `\\n` so the new line character is stored in the .env file and not the actual line break. When React displays the text from the .env file, all occurrences of `\\n` are replaced back to `\n` so that the line breaks are rendered correctly.

config.yaml:
```
...
search_description: "Ask\na\nb\no\nut anything related to startups, entrepreneurship, or venture capital."
...
```

Result:
<img width="529" alt="Screenshot 2023-07-19 at 10 47 05 AM" src="https://github.com/vectara/vectara-answer/assets/29833473/e766811e-353a-4d6b-b713-10a70a160a55">
