### PR TITLE
Fix excessive search requests

### DIFF
--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -105,7 +105,7 @@ export const SearchContextProvider = ({ children }: Props) => {
   // Use the browser back and forward buttons to traverse history
   // of searches, and bookmark or share the URL.
   useEffect(() => {
-    if (!isConfigLoaded) return;
+    if (!isConfigLoaded || isSearching) return;
 
     const urlParams = new URLSearchParams(searchParams);
 


### PR DESCRIPTION
When a search query is made on the Vectara answers website, 4 requests are sent to the Vectara API when only 2 should be sent (one for search request and one for summary).

I did some debugging and discovered that useEffect hook is causing the excessive requests: 
https://github.com/vectara/vectara-answer/blob/b93af31b21546538998747f62580a95da7ac622e/src/contexts/SearchContext.tsx#L107C2-L121C1

To fix the bug I added a simple check to prevent another search request from being sent if it's already searching.

Before fix:
<img width="503" alt="Screenshot 2023-07-21 at 4 58 24 PM" src="https://github.com/vectara/vectara-answer/assets/29833473/84560b0f-5a00-4f12-ab78-77f5059bb09c">
After fix:
<img width="500" alt="Screenshot 2023-07-21 at 4 59 13 PM" src="https://github.com/vectara/vectara-answer/assets/29833473/c3e396c4-c2a9-46d1-895d-37892c781b44">
