### PR TITLE
Reorder references based on summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ sources: "BBC,NPR,FOX,CNBC,CNN"
 The way summarization works can be configured as follows:
 
 ```yaml
-# Hide or show summary (if not specified defaults to True). When set to False, it hides the summary and prevents the call to the summarization API.
+# Switches between summary mode and search results mode (if not specified defaults to True). When set to True, a summary is shown along with references used in the summary. When set to False, only search results are shown and no calls made to the summarization API.
 enable_summary: True
 
 # Default language for summary response (if not specified defaults to "auto")

--- a/config/ask-HBS/config.yaml
+++ b/config/ask-HBS/config.yaml
@@ -11,7 +11,7 @@ summary_num_results: 10
 rerank: true
 rerank_num_results: 100
 
-enable_summary: false
+summary_mode: false
 
 enable_source_filters: False
 source: ""

--- a/config/pg-search/config.yaml
+++ b/config/pg-search/config.yaml
@@ -1,0 +1,10 @@
+corpus_id: 1
+customer_id: 405606997
+
+search_title: "Ask Paul Graham"
+search_description: "Ask about anything related to startups, entrepreneurship, or venture capital."
+
+enable_source_filters: False
+source: ""
+
+summary_mode: False

--- a/config/pg-search/queries.json
+++ b/config/pg-search/queries.json
@@ -1,0 +1,8 @@
+{
+    "questions": [
+        "What is a maker schedule?",
+        "How do I detect bias?",
+        "What makes a good founder?",
+        "Why did Yahoo fail?"
+    ]
+}

--- a/docker/server/index.js
+++ b/docker/server/index.js
@@ -58,7 +58,7 @@ app.post("/config", (req, res) => {
     sources,
 
     // summary
-    enable_summary,
+    summary_mode,
     summary_default_language,
     summary_num_results,
     summary_num_sentences,
@@ -110,7 +110,7 @@ app.post("/config", (req, res) => {
     sources,
 
     // summary
-    enable_summary,
+    summary_mode,
     summary_default_language,
     summary_num_results,
     summary_num_sentences,

--- a/server/index.js
+++ b/server/index.js
@@ -57,7 +57,7 @@ app.post("/config", (req, res) => {
     sources,
 
     // summary
-    enable_summary,
+    summary_mode,
     summary_default_language,
     summary_num_results,
     summary_num_sentences,
@@ -109,7 +109,7 @@ app.post("/config", (req, res) => {
     sources,
 
     // summary
-    enable_summary,
+    summary_mode,
     summary_default_language,
     summary_num_results,
     summary_num_sentences,

--- a/src/contexts/ConfigurationContext.tsx
+++ b/src/contexts/ConfigurationContext.tsx
@@ -7,10 +7,7 @@ import {
 } from "react";
 import axios from "axios";
 
-import {
-  SummaryLanguage,
-  SUMMARY_LANGUAGES,
-} from "../views/search/types";
+import { SummaryLanguage, SUMMARY_LANGUAGES } from "../views/search/types";
 
 interface Config {
   // Search
@@ -54,10 +51,10 @@ interface Config {
   config_full_story_org_id?: string;
 
   // Summary
-  config_enable_summary?: string;
+  config_summary_mode?: string;
   config_summary_default_language?: string;
-  config_summary_num_results?: number,
-  config_summary_num_sentences?: number,
+  config_summary_num_results?: number;
+  config_summary_num_sentences?: number;
 
   // rerank
   config_rerank?: string;
@@ -122,7 +119,10 @@ type SearchHeader = {
 
 type ExampleQuestions = string[];
 type Auth = { isEnabled: boolean; googleClientId?: string };
-type Analytics = { googleAnalyticsTrackingCode?: string; fullStoryOrgId?: string };
+type Analytics = {
+  googleAnalyticsTrackingCode?: string;
+  fullStoryOrgId?: string;
+};
 type Rerank = { isEnabled: boolean; numResults?: number };
 
 interface ConfigContextType {
@@ -132,8 +132,8 @@ interface ConfigContextType {
   app: App;
   appHeader: AppHeader;
   filters: Filters;
-  summary: Summary,
-  rerank: Rerank,
+  summary: Summary;
+  rerank: Rerank;
   searchHeader: SearchHeader;
   exampleQuestions: ExampleQuestions;
   auth: Auth;
@@ -194,7 +194,10 @@ const prefixConfig = (
   return prefixedConfig;
 };
 
-const validateLanguage = (lang: string, defaultLanguage: SummaryLanguage): SummaryLanguage => {
+const validateLanguage = (
+  lang: string,
+  defaultLanguage: SummaryLanguage
+): SummaryLanguage => {
   if ((SUMMARY_LANGUAGES as readonly string[]).includes(lang)) {
     return lang as SummaryLanguage;
   }
@@ -225,7 +228,10 @@ export const ConfigContextProvider = ({ children }: Props) => {
   );
   const [auth, setAuth] = useState<Auth>({ isEnabled: false });
   const [analytics, setAnalytics] = useState<Analytics>({});
-  const [rerank, setRerank] = useState<Rerank>({ isEnabled: false, numResults: 100 });
+  const [rerank, setRerank] = useState<Rerank>({
+    isEnabled: false,
+    numResults: 100,
+  });
 
   const [summary, setSummary] = useState<Summary>({
     isEnabled: true,
@@ -314,7 +320,7 @@ export const ConfigContextProvider = ({ children }: Props) => {
         config_rerank_num_results,
 
         // Summary
-        config_enable_summary,
+        config_summary_mode,
         config_summary_default_language,
         config_summary_num_results,
         config_summary_num_sentences,
@@ -356,9 +362,9 @@ export const ConfigContextProvider = ({ children }: Props) => {
 
       const sourceValueToLabelMap = sources.length
         ? sources.reduce((accum, { label, value }) => {
-          accum[value] = label;
-          return accum;
-        }, {} as Record<string, string>)
+            accum[value] = label;
+            return accum;
+          }, {} as Record<string, string>)
         : undefined;
 
       if (isFilteringEnabled && sources.length === 0) {
@@ -374,8 +380,11 @@ export const ConfigContextProvider = ({ children }: Props) => {
       });
 
       setSummary({
-        isEnabled: isTrue(config_enable_summary ?? "True"),
-        defaultLanguage: validateLanguage(config_summary_default_language as SummaryLanguage, "auto"),
+        isEnabled: isTrue(config_summary_mode ?? "True"),
+        defaultLanguage: validateLanguage(
+          config_summary_default_language as SummaryLanguage,
+          "auto"
+        ),
         summaryNumResults: config_summary_num_results ?? 7,
         summaryNumSentences: config_summary_num_sentences ?? 3,
       });
@@ -406,7 +415,6 @@ export const ConfigContextProvider = ({ children }: Props) => {
         isEnabled: isTrue(config_rerank),
         numResults: config_rerank_num_results ?? rerank.numResults,
       });
-
     };
     loadConfig();
   }, []);

--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -42,7 +42,7 @@ interface SearchContextType {
   isSearching: boolean;
   searchError: any;
   searchResults: DeserializedSearchResult[] | undefined;
-  includeSummary: boolean;
+  summaryMode: boolean;
   isSummarizing: boolean;
   summarizationError: any;
   summarizationResponse: SearchResponse | undefined;
@@ -230,7 +230,7 @@ export const SearchContextProvider = ({ children }: Props) => {
           const response = await sendSearchRequest({
             filter,
             query_str: value,
-            includeSummary: true,
+            summaryMode: true,
             rerank: rerank.isEnabled,
             rerankNumResults: rerank.numResults,
             summaryNumResults: summary.summaryNumResults,
@@ -284,7 +284,7 @@ export const SearchContextProvider = ({ children }: Props) => {
         isSearching,
         searchError,
         searchResults,
-        includeSummary: summary.isEnabled,
+        summaryMode: summary.isEnabled,
         isSummarizing,
         summarizationError,
         summarizationResponse,

--- a/src/contexts/sendSearchRequest.ts
+++ b/src/contexts/sendSearchRequest.ts
@@ -6,7 +6,7 @@ type Config = {
   filter: string;
   query_str?: string;
   language?: SummaryLanguage;
-  includeSummary?: boolean;
+  summaryMode?: boolean;
   rerank?: boolean;
   rerankNumResults?: number;
   summaryNumResults?: number;
@@ -21,7 +21,7 @@ export const sendSearchRequest = async ({
   filter,
   query_str,
   language,
-  includeSummary,
+  summaryMode,
   rerank,
   rerankNumResults,
   summaryNumResults,
@@ -54,27 +54,28 @@ export const sendSearchRequest = async ({
         numResults: rerank ? rerankNumResults : 10,
         corpusKey: corpusKeyList,
         context_config: {
-          sentences_before: includeSummary ? summaryNumSentences : 2,
-          sentences_after: includeSummary ? summaryNumSentences : 2,
+          sentences_before: summaryMode ? summaryNumSentences : 2,
+          sentences_after: summaryMode ? summaryNumSentences : 2,
           start_tag: START_TAG,
           end_tag: END_TAG,
         },
-        ...(includeSummary
+        ...(summaryMode
           ? {
-            summary: [
-              {
-                responseLang: language,
-                maxSummarizedResults: summaryNumResults,
-              },
-            ],
-          }
+              summary: [
+                {
+                  responseLang: language,
+                  maxSummarizedResults: summaryNumResults,
+                },
+              ],
+            }
           : {}),
         ...(rerank
           ? {
-            reranking_config: {
-              reranker_id: 272725717
-            },
-          } : {}),
+              reranking_config: {
+                reranker_id: 272725717,
+              },
+            }
+          : {}),
       },
     ],
   };

--- a/src/views/search/SearchView.tsx
+++ b/src/views/search/SearchView.tsx
@@ -18,6 +18,21 @@ import { useConfigContext } from "../../contexts/ConfigurationContext";
 import { HistoryDrawer } from "./controls/HistoryDrawer";
 import "./searchView.scss";
 
+const reorderCitations = (unorderedSummary: string) => {
+  const allCitations = unorderedSummary.match(/\[\d+\]/g) || [];
+
+  const uniqueCitations = [...new Set(allCitations)];
+  const citationToReplacement: { [key: string]: string } = {};
+  uniqueCitations.forEach((citation, index) => {
+    citationToReplacement[citation] = `[${index + 1}]`;
+  });
+
+  return unorderedSummary.replace(
+    /\[\d+\]/g,
+    (match) => citationToReplacement[match]
+  );
+};
+
 export const SearchView = () => {
   const { isConfigLoaded, app } = useConfigContext();
 
@@ -63,7 +78,10 @@ export const SearchView = () => {
   ) {
     content = <ExampleQuestions />;
   } else {
-    const summary = summarizationResponse?.summary[0]?.text;
+    const unorderedSummary = summarizationResponse?.summary[0]?.text;
+    let summary = "";
+    if (unorderedSummary) summary = reorderCitations(unorderedSummary);
+
     content = (
       <>
         <VuiSpacer size="s" />
@@ -76,7 +94,9 @@ export const SearchView = () => {
               summarizationError={summarizationError}
               summary={summary}
               selectedSearchResultPosition={selectedSearchResultPosition}
-              onClickCitation={(position: number) => selectSearchResultAt(position - 1)}
+              onClickCitation={(position: number) =>
+                selectSearchResultAt(position - 1)
+              }
             />
             <VuiSpacer size="l" />
             <VuiHorizontalRule />

--- a/src/views/search/SearchView.tsx
+++ b/src/views/search/SearchView.tsx
@@ -25,7 +25,7 @@ export const SearchView = () => {
     isSearching,
     searchError,
     searchResults,
-    includeSummary,
+    summaryMode,
     isSummarizing,
     summarizationError,
     summarizationResponse,
@@ -68,7 +68,7 @@ export const SearchView = () => {
       <>
         <VuiSpacer size="s" />
 
-        {includeSummary && (
+        {summaryMode && (
           <>
             <VuiSpacer size="s" />
             <Summary
@@ -92,7 +92,7 @@ export const SearchView = () => {
           setSearchResultRef={(el: HTMLDivElement | null, index: number) =>
             ((searchResultsRef as any).current[index] = el)
           }
-          includeSummary={includeSummary}
+          summaryMode={summaryMode}
         />
       </>
     );

--- a/src/views/search/results/SearchResults.tsx
+++ b/src/views/search/results/SearchResults.tsx
@@ -12,7 +12,7 @@ import {
 import { SearchResultList } from "./SearchResultList";
 
 type Props = {
-  includeSummary: boolean;
+  summaryMode: boolean;
   isSearching: boolean;
   searchError?: any;
   results?: DeserializedSearchResult[];
@@ -21,7 +21,7 @@ type Props = {
 };
 
 export const SearchResults = ({
-  includeSummary,
+  summaryMode,
   isSearching,
   searchError,
   results,
@@ -75,7 +75,7 @@ export const SearchResults = ({
     );
   }
 
-  const searchHeaderText = includeSummary ? "References" : "Search Results";
+  const searchHeaderText = summaryMode ? "References" : "Search Results";
 
   return (
     <>


### PR DESCRIPTION
This PR reorders the references to match the summary when summary mode is turned on. I also renamed the enable_summary config option with summary_mode.

### Problem: The references section now needs to wait for the summary to load before it's shown. How should we tackle this?
![Screenshot 2023-08-22 at 10 18 41 AM](https://github.com/vectara/vectara-answer/assets/29833473/e0106250-909a-4fcc-9574-82113bc6444a)
### Example
![Screenshot 2023-08-22 at 10 17 35 AM](https://github.com/vectara/vectara-answer/assets/29833473/ab1bb516-0e23-4372-8366-847ce1e83f70)
