### PR TITLE
Surface more feedback about loading speed

### DIFF
--- a/src/contexts/ConfigurationContext.tsx
+++ b/src/contexts/ConfigurationContext.tsx
@@ -59,7 +59,7 @@ interface Config {
   config_summary_default_language?: string;
   config_summary_num_results?: number;
   config_summary_num_sentences?: number;
-  config_summary_prompt_name?: string
+  config_summary_prompt_name?: string;
 
   // rerank
   config_rerank?: string;
@@ -81,7 +81,6 @@ type App = {
   isHeaderEnabled: boolean;
   isFooterEnabled: boolean;
   title: string;
-  uxMode: UxMode;
 };
 
 type AppHeader = {
@@ -134,6 +133,8 @@ type Rerank = { isEnabled: boolean; numResults?: number };
 interface ConfigContextType {
   isConfigLoaded: boolean;
   missingConfigProps: string[];
+  uxMode: UxMode;
+  setUxMode: (uxMode: UxMode) => void;
   search: Search;
   app: App;
   appHeader: AppHeader;
@@ -213,12 +214,12 @@ const validateLanguage = (
 export const ConfigContextProvider = ({ children }: Props) => {
   const [isConfigLoaded, setIsConfigLoaded] = useState(false);
   const [missingConfigProps, setMissingConfigProps] = useState<string[]>([]);
+  const [uxMode, setUxMode] = useState<UxMode>("summary");
   const [search, setSearch] = useState<Search>({});
   const [app, setApp] = useState<App>({
     isHeaderEnabled: false,
     isFooterEnabled: false,
     title: "",
-    uxMode: "summary",
   });
   const [appHeader, setAppHeader] = useState<AppHeader>({
     logo: {},
@@ -334,6 +335,8 @@ export const ConfigContextProvider = ({ children }: Props) => {
         config_summary_prompt_name,
       } = config;
 
+      setUxMode(config_ux ?? "summary");
+
       setSearch({
         endpoint: config_endpoint,
         corpusId: config_corpus_id,
@@ -345,7 +348,6 @@ export const ConfigContextProvider = ({ children }: Props) => {
         title: config_app_title ?? "",
         isHeaderEnabled: isTrue(config_enable_app_header ?? "True"),
         isFooterEnabled: isTrue(config_enable_app_footer ?? "True"),
-        uxMode: config_ux ?? "summary",
       });
 
       setAppHeader({
@@ -395,7 +397,8 @@ export const ConfigContextProvider = ({ children }: Props) => {
         ),
         summaryNumResults: config_summary_num_results ?? 7,
         summaryNumSentences: config_summary_num_sentences ?? 3,
-        summaryPromptName: config_summary_prompt_name ?? "vectara-summary-ext-v1.2.0",
+        summaryPromptName:
+          config_summary_prompt_name ?? "vectara-summary-ext-v1.2.0",
       });
 
       setSearchHeader({
@@ -426,7 +429,7 @@ export const ConfigContextProvider = ({ children }: Props) => {
       });
     };
     loadConfig();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
@@ -434,6 +437,8 @@ export const ConfigContextProvider = ({ children }: Props) => {
       value={{
         isConfigLoaded,
         missingConfigProps,
+        uxMode,
+        setUxMode,
         search,
         app,
         appHeader,

--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -73,8 +73,9 @@ type Props = {
 let searchCount = 0;
 
 export const SearchContextProvider = ({ children }: Props) => {
-  const { isConfigLoaded, search, summary, rerank, app } = useConfigContext();
-  const isSummaryEnabled = app.uxMode === "summary";
+  const { isConfigLoaded, search, summary, rerank, uxMode } =
+    useConfigContext();
+  const isSummaryEnabled = uxMode === "summary";
 
   const [searchValue, setSearchValue] = useState<string>("");
   const [filterValue, setFilterValue] = useState("");

--- a/src/ui/components/flex/FlexItem.tsx
+++ b/src/ui/components/flex/FlexItem.tsx
@@ -4,26 +4,44 @@ import { ReactNode } from "react";
 const GROW = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
 const SHRINK = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const;
 
+const alignItemsToClassNameMap = {
+  baseline: "vuiFlexItem--alignItemsBaseline",
+  center: "vuiFlexItem--alignItemsCenter",
+  end: "vuiFlexItem--alignItemsEnd",
+  start: "vuiFlexItem--alignItemsStart",
+  stretch: "vuiFlexItem--alignItemsStretch",
+} as const;
+
 type Props = {
   children?: ReactNode;
   grow?: (typeof GROW)[number] | boolean;
   shrink?: (typeof SHRINK)[number] | boolean;
+  alignItems?: keyof typeof alignItemsToClassNameMap;
   className?: string;
   truncate?: boolean;
 };
 
-export const VuiFlexItem = ({ children, grow, shrink, className, truncate, ...rest }: Props) => {
+export const VuiFlexItem = ({
+  children,
+  grow,
+  shrink,
+  alignItems = "stretch",
+  className,
+  truncate,
+  ...rest
+}: Props) => {
   const isGrowNone = grow === false;
   const isShrinkNone = shrink === false;
 
   const classes = classNames(
     "vuiFlexItem",
+    alignItemsToClassNameMap[alignItems],
     {
       [`vuiFlexItem--flexGrow${grow}`]: typeof grow === "number",
       "vuiFlexItem--flexGrowNone": isGrowNone,
       [`vuiFlexItem--flexShrink${shrink}`]: typeof shrink === "number",
       "vuiFlexItem--flexShrinkNone": isShrinkNone,
-      "vuiFlexItem--truncate": truncate
+      "vuiFlexItem--truncate": truncate,
     },
     className
   );

--- a/src/ui/components/flex/_flexItem.scss
+++ b/src/ui/components/flex/_flexItem.scss
@@ -9,6 +9,21 @@
   min-width: 40px;
 }
 
+// alignItems
+$alignItems: (
+  alignItemsBaseline: baseline,
+  alignItemsCenter: center,
+  alignItemsEnd: end,
+  alignItemsStart: start,
+  alignItemsStretch: stretch,
+);
+
+@each $alignItemsName, $alignItemsValue in $alignItems {
+  .vuiFlexItem--#{$alignItemsName} {
+    align-items: $alignItemsValue;
+  }
+}
+
 @for $i from 0 through 10 {
   .vuiFlexItem--flexGrow#{$i} {
     flex-grow: $i;

--- a/src/ui/components/flex/_flexItem.scss
+++ b/src/ui/components/flex/_flexItem.scss
@@ -1,6 +1,7 @@
 .vuiFlexItem {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   flex-basis: 0%;
 }
 

--- a/src/ui/components/list/List.tsx
+++ b/src/ui/components/list/List.tsx
@@ -2,8 +2,10 @@ import classNames from "classnames";
 import { VuiFlexContainer } from "../flex/FlexContainer";
 import { VuiFlexItem } from "../flex/FlexItem";
 import { VuiSpacer } from "../spacer/Spacer";
+import { Fragment } from "react";
 
 type ListItem = {
+  key: string;
   isComplete: boolean;
   render: () => React.ReactNode;
 };
@@ -18,14 +20,17 @@ export const VuiList = ({ items }: Props) => {
       {items.map((item, index) => {
         const humanizedStep = index + 1;
         const numberClasses = classNames("vuiListNumber", {
-          "vuiListNumber-isComplete": item.isComplete
+          "vuiListNumber-isComplete": item.isComplete,
         });
 
         return (
-          <>
+          <Fragment key={item.key}>
             <VuiFlexContainer alignItems="center">
               <VuiFlexItem grow={false} shrink={false}>
-                <div className={numberClasses} aria-label={`Step ${humanizedStep}`}>
+                <div
+                  className={numberClasses}
+                  aria-label={`Step ${humanizedStep}`}
+                >
                   {humanizedStep}
                 </div>
               </VuiFlexItem>
@@ -34,7 +39,7 @@ export const VuiList = ({ items }: Props) => {
             </VuiFlexContainer>
 
             {index < items.length - 1 && <VuiSpacer size="s" />}
-          </>
+          </Fragment>
         );
       })}
     </>

--- a/src/ui/components/list/List.tsx
+++ b/src/ui/components/list/List.tsx
@@ -12,20 +12,30 @@ type ListItem = {
 
 type Props = {
   items: ListItem[];
+  size?: "s" | "m";
+  alignItems?: "start" | "center" | "end";
 };
 
-export const VuiList = ({ items }: Props) => {
+export const VuiList = ({
+  items,
+  size = "m",
+  alignItems = "center",
+}: Props) => {
   return (
     <>
       {items.map((item, index) => {
         const humanizedStep = index + 1;
-        const numberClasses = classNames("vuiListNumber", {
-          "vuiListNumber-isComplete": item.isComplete,
-        });
+        const numberClasses = classNames(
+          "vuiListNumber",
+          `vuiListNumber--${size}`,
+          {
+            "vuiListNumber-isComplete": item.isComplete,
+          }
+        );
 
         return (
           <Fragment key={item.key}>
-            <VuiFlexContainer alignItems="center">
+            <VuiFlexContainer alignItems={alignItems} spacing={size}>
               <VuiFlexItem grow={false} shrink={false}>
                 <div
                   className={numberClasses}

--- a/src/ui/components/list/_index.scss
+++ b/src/ui/components/list/_index.scss
@@ -1,16 +1,26 @@
 .vuiListNumber {
   display: flex;
   flex-direction: column;
-  width: $sizeM;
-  height: $sizeM;
-  padding: $sizeM;
   border-radius: $sizeL;
   background-color: $colorLightShade;
   color: $colorSubdued;
-  font-size: $fontSizeMedium;
   font-weight: $fontWeightBold;
   line-height: 0;
   align-items: center;
+}
+
+.vuiListNumber--m {
+  width: $sizeM;
+  height: $sizeM;
+  padding: $sizeM;
+  font-size: $fontSizeMedium;
+}
+
+.vuiListNumber--s {
+  width: $sizeS;
+  height: $sizeS;
+  padding: $sizeS;
+  font-size: $fontSizeSmall;
 }
 
 .vuiListNumber-isComplete {

--- a/src/views/search/SearchView.tsx
+++ b/src/views/search/SearchView.tsx
@@ -21,7 +21,7 @@ const uxModeToComponentMap = {
 } as const;
 
 export const SearchView = () => {
-  const { isConfigLoaded, app } = useConfigContext();
+  const { isConfigLoaded, app, uxMode } = useConfigContext();
 
   const {
     isSearching,
@@ -59,7 +59,7 @@ export const SearchView = () => {
   ) {
     content = <ExampleQuestions />;
   } else {
-    content = uxModeToComponentMap[app.uxMode];
+    content = uxModeToComponentMap[uxMode];
   }
 
   return (

--- a/src/views/search/SearchView.tsx
+++ b/src/views/search/SearchView.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import {
   VuiFlexContainer,
   VuiFlexItem,
@@ -12,7 +11,6 @@ import { useSearchContext } from "../../contexts/SearchContext";
 import { AppHeader } from "./chrome/AppHeader";
 import { AppFooter } from "./chrome/AppFooter";
 import { useConfigContext } from "../../contexts/ConfigurationContext";
-import { HistoryDrawer } from "./controls/HistoryDrawer";
 import { SearchUx } from "./SearchUx";
 import { SummaryUx } from "./SummaryUx";
 import "./searchView.scss";
@@ -33,8 +31,6 @@ export const SearchView = () => {
     summarizationError,
     summarizationResponse,
   } = useSearchContext();
-
-  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
 
   let content;
 
@@ -77,22 +73,13 @@ export const SearchView = () => {
       >
         {isConfigLoaded && (
           <VuiFlexItem className="searchControlsContainer">
-            <SearchControls
-              isHistoryOpen={isHistoryOpen}
-              onToggleHistory={() => setIsHistoryOpen(!isHistoryOpen)}
-              hasQuery={Boolean(isSearching || searchResults)}
-            />
+            <SearchControls hasQuery={Boolean(isSearching || searchResults)} />
           </VuiFlexItem>
         )}
 
         <VuiFlexItem grow={1} className="searchContent">
           {content}
         </VuiFlexItem>
-
-        <HistoryDrawer
-          isOpen={isHistoryOpen}
-          onClose={() => setIsHistoryOpen(false)}
-        />
 
         {app.isFooterEnabled && <AppFooter />}
       </VuiFlexContainer>

--- a/src/views/search/SummaryUx.tsx
+++ b/src/views/search/SummaryUx.tsx
@@ -51,11 +51,7 @@ export const SummaryUx = () => {
 
   return (
     <>
-      <ProgressReport
-        isSearching={isSearching}
-        isSummarizing={isSummarizing}
-        searchResults={searchResults}
-      />
+      <ProgressReport isSearching={isSearching} isSummarizing={isSummarizing} />
 
       <VuiSpacer size="l" />
 

--- a/src/views/search/SummaryUx.tsx
+++ b/src/views/search/SummaryUx.tsx
@@ -1,17 +1,4 @@
-import { BiCheck } from "react-icons/bi";
-import {
-  VuiFlexContainer,
-  VuiFlexItem,
-  VuiSpacer,
-  VuiTitle,
-  VuiSpinner,
-  VuiHorizontalRule,
-  VuiIcon,
-  VuiText,
-  VuiTextColor,
-  VuiList,
-  VuiSummary,
-} from "../../ui";
+import { VuiSpacer, VuiTitle, VuiHorizontalRule, VuiSummary } from "../../ui";
 import {
   sanitizeCitations,
   reorderCitations,
@@ -21,6 +8,7 @@ import { useSearchContext } from "../../contexts/SearchContext";
 import { SearchErrorCallout } from "./results/SearchErrorCallout";
 import { SummaryErrorCallout } from "./results/SummaryErrorCallout";
 import { SearchResultList } from "./results/SearchResultList";
+import { ProgressReport } from "./progressReport/ProgressReport";
 import { DeserializedSearchResult } from "./types";
 
 export const SummaryUx = () => {
@@ -36,83 +24,7 @@ export const SummaryUx = () => {
     selectSearchResultAt,
   } = useSearchContext();
 
-  if (isSearching || isSummarizing) {
-    let items;
-
-    if (isSearching) {
-      items = [
-        {
-          key: "retrieveInfo",
-          isComplete: true,
-          render: () => (
-            <VuiFlexContainer alignItems="center" spacing="xs">
-              <VuiFlexItem>
-                <VuiSpinner size="s" />
-              </VuiFlexItem>
-
-              <VuiFlexItem grow={false}>
-                <VuiText>
-                  <p>Retrieving information</p>
-                </VuiText>
-              </VuiFlexItem>
-            </VuiFlexContainer>
-          ),
-        },
-        {
-          key: "generateSummary",
-          isComplete: false,
-          render: () => (
-            <VuiText>
-              <p>
-                <VuiTextColor color="subdued">Generate summary</VuiTextColor>
-              </p>
-            </VuiText>
-          ),
-        },
-      ];
-    } else {
-      items = [
-        {
-          key: "retrieveInfo",
-          isComplete: true,
-          render: () => (
-            <VuiFlexContainer alignItems="center" spacing="xs">
-              <VuiFlexItem>
-                <VuiIcon size="s" color="success">
-                  <BiCheck />
-                </VuiIcon>
-              </VuiFlexItem>
-
-              <VuiFlexItem grow={false}>
-                <VuiText>
-                  <p>Retrieved information</p>
-                </VuiText>
-              </VuiFlexItem>
-            </VuiFlexContainer>
-          ),
-        },
-        {
-          key: "generateSummary",
-          isComplete: true,
-          render: () => (
-            <VuiFlexContainer alignItems="center" spacing="xs">
-              <VuiFlexItem>
-                <VuiSpinner size="s" />
-              </VuiFlexItem>
-
-              <VuiFlexItem grow={false}>
-                <VuiText>
-                  <p>Generating summary</p>
-                </VuiText>
-              </VuiFlexItem>
-            </VuiFlexContainer>
-          ),
-        },
-      ];
-    }
-
-    return <VuiList items={items} />;
-  } else if (searchError || summarizationError) {
+  if (searchError || summarizationError) {
     return searchError ? (
       <SearchErrorCallout searchError={searchError} />
     ) : (
@@ -126,6 +38,7 @@ export const SummaryUx = () => {
 
   let summary = "";
   let summarySearchResults: DeserializedSearchResult[] = [];
+
   if (!isSummarizing && unorderedSummary) {
     summary = reorderCitations(unorderedSummary);
     if (searchResults) {
@@ -138,6 +51,14 @@ export const SummaryUx = () => {
 
   return (
     <>
+      <ProgressReport
+        isSearching={isSearching}
+        isSummarizing={isSummarizing}
+        searchResults={searchResults}
+      />
+
+      <VuiSpacer size="l" />
+
       <VuiTitle size="xs">
         <h2>
           <strong>Summary</strong>

--- a/src/views/search/SummaryUx.tsx
+++ b/src/views/search/SummaryUx.tsx
@@ -42,6 +42,7 @@ export const SummaryUx = () => {
     if (isSearching) {
       items = [
         {
+          key: "retrieveInfo",
           isComplete: true,
           render: () => (
             <VuiFlexContainer alignItems="center" spacing="xs">
@@ -58,6 +59,7 @@ export const SummaryUx = () => {
           ),
         },
         {
+          key: "generateSummary",
           isComplete: false,
           render: () => (
             <VuiText>
@@ -71,6 +73,7 @@ export const SummaryUx = () => {
     } else {
       items = [
         {
+          key: "retrieveInfo",
           isComplete: true,
           render: () => (
             <VuiFlexContainer alignItems="center" spacing="xs">
@@ -89,6 +92,7 @@ export const SummaryUx = () => {
           ),
         },
         {
+          key: "generateSummary",
           isComplete: true,
           render: () => (
             <VuiFlexContainer alignItems="center" spacing="xs">

--- a/src/views/search/controls/OptionsDrawer.tsx
+++ b/src/views/search/controls/OptionsDrawer.tsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import { BiSlider } from "react-icons/bi";
+import { useSearchContext } from "../../../contexts/SearchContext";
+import {
+  VuiButtonPrimary,
+  VuiButtonTertiary,
+  VuiDrawer,
+  VuiFlexContainer,
+  VuiFlexItem,
+  VuiFormGroup,
+  VuiHorizontalRule,
+  VuiIcon,
+  VuiSelect,
+  VuiSpacer,
+  VuiTitle,
+} from "../../../ui";
+import { SUMMARY_LANGUAGES, SummaryLanguage, humanizeLanguage } from "../types";
+
+const languageOptions = SUMMARY_LANGUAGES.map((code) => ({
+  value: code,
+  text: humanizeLanguage(code),
+}));
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export const OptionsDrawer = ({ isOpen, onClose }: Props) => {
+  const { language, onSearch } = useSearchContext();
+  const [newLanguage, setNewLanguage] = useState<SummaryLanguage>(language);
+
+  return (
+    <VuiDrawer
+      isOpen={isOpen}
+      onClose={onClose}
+      title={
+        <VuiFlexContainer
+          justifyContent="spaceBetween"
+          alignItems="center"
+          spacing="xs"
+        >
+          <VuiFlexItem>
+            <VuiIcon size="s">
+              <BiSlider />
+            </VuiIcon>
+          </VuiFlexItem>
+
+          <VuiFlexItem>
+            <VuiTitle size="s">
+              <h2>Options</h2>
+            </VuiTitle>
+          </VuiFlexItem>
+        </VuiFlexContainer>
+      }
+    >
+      <VuiFormGroup
+        label="Summary language"
+        labelFor="languageSelect"
+        helpText="Summaries will be written in this language."
+      >
+        <VuiSelect
+          id="languageSelect"
+          options={languageOptions}
+          value={newLanguage}
+          onChange={(e: any) => {
+            setNewLanguage(e.target.value);
+          }}
+        />
+      </VuiFormGroup>
+
+      <VuiSpacer size="l" />
+
+      <VuiHorizontalRule />
+
+      <VuiSpacer size="m" />
+
+      <VuiFlexContainer justifyContent="spaceBetween" alignItems="center">
+        <VuiFlexItem grow={false} shrink={false}>
+          <VuiButtonTertiary color="primary" onClick={() => onClose()}>
+            Cancel
+          </VuiButtonTertiary>
+        </VuiFlexItem>
+
+        <VuiFlexItem grow={false} shrink={false}>
+          <VuiButtonPrimary
+            color="primary"
+            onClick={() => {
+              onSearch({
+                language: newLanguage as SummaryLanguage,
+              });
+              onClose();
+            }}
+          >
+            Save
+          </VuiButtonPrimary>
+        </VuiFlexItem>
+      </VuiFlexContainer>
+    </VuiDrawer>
+  );
+};

--- a/src/views/search/controls/OptionsDrawer.tsx
+++ b/src/views/search/controls/OptionsDrawer.tsx
@@ -15,11 +15,23 @@ import {
   VuiTitle,
 } from "../../../ui";
 import { SUMMARY_LANGUAGES, SummaryLanguage, humanizeLanguage } from "../types";
+import { useConfigContext } from "../../../contexts/ConfigurationContext";
 
 const languageOptions = SUMMARY_LANGUAGES.map((code) => ({
   value: code,
   text: humanizeLanguage(code),
 }));
+
+const uxModeOptions = [
+  {
+    value: "summary",
+    text: "Summary",
+  },
+  {
+    value: "search",
+    text: "Search",
+  },
+];
 
 type Props = {
   isOpen: boolean;
@@ -27,7 +39,10 @@ type Props = {
 };
 
 export const OptionsDrawer = ({ isOpen, onClose }: Props) => {
+  const { uxMode, setUxMode } = useConfigContext();
   const { language, onSearch } = useSearchContext();
+
+  const [newUxMode, setNewUxMode] = useState(uxMode);
   const [newLanguage, setNewLanguage] = useState<SummaryLanguage>(language);
 
   return (
@@ -69,6 +84,23 @@ export const OptionsDrawer = ({ isOpen, onClose }: Props) => {
         />
       </VuiFormGroup>
 
+      <VuiSpacer size="m" />
+
+      <VuiFormGroup
+        label="UX mode"
+        labelFor="uxModeSelect"
+        helpText="Focus the user experience on the search results or the summary."
+      >
+        <VuiSelect
+          id="uxModeSelect"
+          options={uxModeOptions}
+          value={newUxMode}
+          onChange={(e: any) => {
+            setNewUxMode(e.target.value);
+          }}
+        />
+      </VuiFormGroup>
+
       <VuiSpacer size="l" />
 
       <VuiHorizontalRule />
@@ -86,9 +118,13 @@ export const OptionsDrawer = ({ isOpen, onClose }: Props) => {
           <VuiButtonPrimary
             color="primary"
             onClick={() => {
-              onSearch({
-                language: newLanguage as SummaryLanguage,
-              });
+              if (newLanguage !== language) {
+                onSearch({
+                  language: newLanguage as SummaryLanguage,
+                });
+              }
+
+              setUxMode(newUxMode);
               onClose();
             }}
           >

--- a/src/views/search/controls/SearchControls.tsx
+++ b/src/views/search/controls/SearchControls.tsx
@@ -1,4 +1,5 @@
 import { ChangeEvent, FormEvent, useState } from "react";
+import { BiSlider, BiTimeFive } from "react-icons/bi";
 import { useConfigContext } from "../../../contexts/ConfigurationContext";
 import {
   VuiFlexContainer,
@@ -10,42 +11,24 @@ import {
   VuiText,
   VuiBadge,
   VuiIcon,
-  VuiPopover,
-  VuiOptionsList,
   VuiButtonSecondary,
   VuiLink,
 } from "../../../ui";
 import { useSearchContext } from "../../../contexts/SearchContext";
 import "./searchControls.scss";
-import { BiCaretDown, BiTimeFive } from "react-icons/bi";
-import { SUMMARY_LANGUAGES, SummaryLanguage, humanizeLanguage } from "../types";
-
-const languageOptions = SUMMARY_LANGUAGES.map((code) => ({
-  value: code,
-  label: humanizeLanguage(code),
-}));
+import { HistoryDrawer } from "./HistoryDrawer";
+import { OptionsDrawer } from "./OptionsDrawer";
 
 type Props = {
-  isHistoryOpen: boolean;
-  onToggleHistory: () => void;
   hasQuery: boolean;
 };
 
-export const SearchControls = ({
-  isHistoryOpen,
-  onToggleHistory,
-  hasQuery,
-}: Props) => {
-  const {
-    filterValue,
-    searchValue,
-    setSearchValue,
-    language,
-    onSearch,
-    reset,
-  } = useSearchContext();
+export const SearchControls = ({ hasQuery }: Props) => {
+  const { filterValue, searchValue, setSearchValue, onSearch, reset } =
+    useSearchContext();
   const { searchHeader, filters } = useConfigContext();
-  const [isLanguageMenuOpen, setIsLanguageMenuOpen] = useState(false);
+  const [isOptionsOpen, setIsOptionsOpen] = useState(false);
+  const [isHistoryOpen, setIsHistoryOpen] = useState(false);
 
   const onSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
     setSearchValue(event.target.value);
@@ -70,182 +53,178 @@ export const SearchControls = ({
   }
 
   return (
-    <div className="searchControls">
-      <VuiFlexContainer alignItems="center" justifyContent="spaceBetween">
-        <VuiFlexItem grow={false}>
-          <VuiFlexContainer alignItems="center">
-            {searchHeader.logo.src && (
-              <VuiFlexItem>
-                <a
-                  href={searchHeader.logo.link ?? "/"}
-                  target={
-                    searchHeader.logo.link !== undefined ? "_blank" : "_self"
-                  }
-                  rel="noreferrer"
-                >
-                  <img
-                    src={searchHeader.logo.src}
-                    alt={searchHeader.logo.alt}
-                    height={searchHeader.logo.height}
-                  />
-                </a>
-              </VuiFlexItem>
-            )}
-
-            {searchHeader.title && (
-              <VuiFlexItem grow={false}>
-                <VuiTitle size="m">
-                  <VuiLink href="/">
-                    <h2>
-                      <strong>{searchHeader.title}</strong>
-                    </h2>
-                  </VuiLink>
-                </VuiTitle>
-              </VuiFlexItem>
-            )}
-          </VuiFlexContainer>
-        </VuiFlexItem>
-
-        <VuiFlexItem grow={false}>
-          <VuiFlexContainer alignItems="center" spacing="m">
-            {searchHeader.description && (
-              <VuiFlexItem grow={false}>
-                <VuiTitle size="xxs" align="right">
-                  <VuiTextColor color="subdued">
-                    <h2 style={{ whiteSpace: "pre-line" }}>
-                      {searchHeader.description.replaceAll("\\n", "\n")}
-                    </h2>
-                  </VuiTextColor>
-                </VuiTitle>
-              </VuiFlexItem>
-            )}
-
-            <VuiFlexItem grow={false}>
-              <VuiPopover
-                isOpen={isLanguageMenuOpen}
-                setIsOpen={setIsLanguageMenuOpen}
-                button={
-                  <VuiButtonSecondary
-                    color="neutral"
-                    size="s"
-                    icon={
-                      <VuiIcon size="m">
-                        <BiCaretDown />
-                      </VuiIcon>
+    <>
+      <div className="searchControls">
+        <VuiFlexContainer alignItems="center" justifyContent="spaceBetween">
+          <VuiFlexItem grow={false}>
+            <VuiFlexContainer alignItems="center">
+              {searchHeader.logo.src && (
+                <VuiFlexItem>
+                  <a
+                    href={searchHeader.logo.link ?? "/"}
+                    target={
+                      searchHeader.logo.link !== undefined ? "_blank" : "_self"
                     }
+                    rel="noreferrer"
                   >
-                    Language: {humanizeLanguage(language as SummaryLanguage)}
-                  </VuiButtonSecondary>
-                }
-              >
-                <VuiOptionsList
-                  isSelectable
-                  onSelectOption={(value) => {
-                    setIsLanguageMenuOpen(false);
-                    onSearch({
-                      language: value as SummaryLanguage,
-                    });
-                  }}
-                  selected={language}
-                  options={languageOptions}
-                />
-              </VuiPopover>
-            </VuiFlexItem>
+                    <img
+                      src={searchHeader.logo.src}
+                      alt={searchHeader.logo.alt}
+                      height={searchHeader.logo.height}
+                    />
+                  </a>
+                </VuiFlexItem>
+              )}
 
+              {searchHeader.title && (
+                <VuiFlexItem grow={false}>
+                  <VuiTitle size="m">
+                    <VuiLink href="/">
+                      <h2>
+                        <strong>{searchHeader.title}</strong>
+                      </h2>
+                    </VuiLink>
+                  </VuiTitle>
+                </VuiFlexItem>
+              )}
+            </VuiFlexContainer>
+          </VuiFlexItem>
+
+          <VuiFlexItem grow={false}>
+            <VuiFlexContainer alignItems="center" spacing="m">
+              {searchHeader.description && (
+                <VuiFlexItem grow={false}>
+                  <VuiTitle size="xxs" align="right">
+                    <VuiTextColor color="subdued">
+                      <h2 style={{ whiteSpace: "pre-line" }}>
+                        {searchHeader.description.replaceAll("\\n", "\n")}
+                      </h2>
+                    </VuiTextColor>
+                  </VuiTitle>
+                </VuiFlexItem>
+              )}
+
+              <VuiFlexItem grow={false}>
+                <VuiButtonSecondary
+                  color="neutral"
+                  size="s"
+                  isSelected={isOptionsOpen}
+                  onClick={() => setIsOptionsOpen(!isOptionsOpen)}
+                  icon={
+                    <VuiIcon size="m">
+                      <BiSlider />
+                    </VuiIcon>
+                  }
+                >
+                  Options
+                </VuiButtonSecondary>
+              </VuiFlexItem>
+
+              <VuiFlexItem grow={false}>
+                <VuiButtonSecondary
+                  color="neutral"
+                  size="s"
+                  isSelected={isHistoryOpen}
+                  onClick={() => setIsHistoryOpen(!isHistoryOpen)}
+                  icon={
+                    <VuiIcon size="m">
+                      <BiTimeFive />
+                    </VuiIcon>
+                  }
+                >
+                  History
+                </VuiButtonSecondary>
+              </VuiFlexItem>
+            </VuiFlexContainer>
+          </VuiFlexItem>
+        </VuiFlexContainer>
+
+        <VuiSpacer size="m" />
+
+        <VuiSearchInput
+          size="l"
+          value={searchValue}
+          onChange={onSearchChange}
+          onSubmit={onSearchSubmit}
+          placeholder={searchHeader.placeholder ?? ""}
+          autoFocus
+        />
+
+        <VuiSpacer size="m" />
+
+        <VuiFlexContainer alignItems="center" justifyContent="spaceBetween">
+          {filters.isEnabled && (
+            <VuiFlexItem grow={false}>
+              <fieldset>
+                <VuiFlexContainer
+                  alignItems="center"
+                  wrap={true}
+                  spacing="xs"
+                  className="filtersBar"
+                >
+                  <VuiFlexItem grow={false}>
+                    <legend>
+                      <VuiText>
+                        <VuiTextColor color="subdued">
+                          <p>Filter by source</p>
+                        </VuiTextColor>
+                      </VuiText>
+                    </legend>
+                  </VuiFlexItem>
+
+                  <VuiFlexItem grow={1}>
+                    <VuiFlexContainer
+                      alignItems="center"
+                      wrap={true}
+                      spacing="xxs"
+                    >
+                      {filterOptions.map((option) => {
+                        const isSelected = option.value === filterValue;
+                        return (
+                          <VuiFlexItem key={option.value}>
+                            <VuiBadge
+                              color={isSelected ? "primary" : "neutral"}
+                              onClick={() =>
+                                onSearch({
+                                  filter: isSelected ? "" : option.value,
+                                })
+                              }
+                            >
+                              {option.text}
+                            </VuiBadge>
+                          </VuiFlexItem>
+                        );
+                      })}
+                    </VuiFlexContainer>
+                  </VuiFlexItem>
+                </VuiFlexContainer>
+              </fieldset>
+            </VuiFlexItem>
+          )}
+
+          {hasQuery && (
             <VuiFlexItem grow={false}>
               <VuiButtonSecondary
                 color="neutral"
                 size="s"
-                isSelected={isHistoryOpen}
-                onClick={onToggleHistory}
-                icon={
-                  <VuiIcon size="m">
-                    <BiTimeFive />
-                  </VuiIcon>
-                }
+                onClick={() => reset()}
               >
-                History
+                Start over
               </VuiButtonSecondary>
             </VuiFlexItem>
-          </VuiFlexContainer>
-        </VuiFlexItem>
-      </VuiFlexContainer>
+          )}
+        </VuiFlexContainer>
+      </div>
 
-      <VuiSpacer size="m" />
-
-      <VuiSearchInput
-        size="l"
-        value={searchValue}
-        onChange={onSearchChange}
-        onSubmit={onSearchSubmit}
-        placeholder={searchHeader.placeholder ?? ""}
-        autoFocus
+      <HistoryDrawer
+        isOpen={isHistoryOpen}
+        onClose={() => setIsHistoryOpen(false)}
       />
 
-      <VuiSpacer size="m" />
-
-      <VuiFlexContainer alignItems="center" justifyContent="spaceBetween">
-        {filters.isEnabled && (
-          <VuiFlexItem grow={false}>
-            <fieldset>
-              <VuiFlexContainer
-                alignItems="center"
-                wrap={true}
-                spacing="xs"
-                className="filtersBar"
-              >
-                <VuiFlexItem grow={false}>
-                  <legend>
-                    <VuiText>
-                      <VuiTextColor color="subdued">
-                        <p>Filter by source</p>
-                      </VuiTextColor>
-                    </VuiText>
-                  </legend>
-                </VuiFlexItem>
-
-                <VuiFlexItem grow={1}>
-                  <VuiFlexContainer
-                    alignItems="center"
-                    wrap={true}
-                    spacing="xxs"
-                  >
-                    {filterOptions.map((option) => {
-                      const isSelected = option.value === filterValue;
-                      return (
-                        <VuiFlexItem key={option.value}>
-                          <VuiBadge
-                            color={isSelected ? "primary" : "neutral"}
-                            onClick={() =>
-                              onSearch({
-                                filter: isSelected ? "" : option.value,
-                              })
-                            }
-                          >
-                            {option.text}
-                          </VuiBadge>
-                        </VuiFlexItem>
-                      );
-                    })}
-                  </VuiFlexContainer>
-                </VuiFlexItem>
-              </VuiFlexContainer>
-            </fieldset>
-          </VuiFlexItem>
-        )}
-
-        {hasQuery && (
-          <VuiFlexItem grow={false}>
-            <VuiButtonSecondary
-              color="neutral"
-              size="s"
-              onClick={() => reset()}
-            >
-              Start over
-            </VuiButtonSecondary>
-          </VuiFlexItem>
-        )}
-      </VuiFlexContainer>
-    </div>
+      <OptionsDrawer
+        isOpen={isOptionsOpen}
+        onClose={() => setIsOptionsOpen(false)}
+      />
+    </>
   );
 };

--- a/src/views/search/controls/SearchControls.tsx
+++ b/src/views/search/controls/SearchControls.tsx
@@ -13,6 +13,7 @@ import {
   VuiPopover,
   VuiOptionsList,
   VuiButtonSecondary,
+  VuiLink,
 } from "../../../ui";
 import { useSearchContext } from "../../../contexts/SearchContext";
 import "./searchControls.scss";
@@ -94,11 +95,11 @@ export const SearchControls = ({
             {searchHeader.title && (
               <VuiFlexItem grow={false}>
                 <VuiTitle size="m">
-                  <a href="/" target="_self" className="no-underline">
+                  <VuiLink href="/">
                     <h2>
                       <strong>{searchHeader.title}</strong>
                     </h2>
-                  </a>
+                  </VuiLink>
                 </VuiTitle>
               </VuiFlexItem>
             )}

--- a/src/views/search/controls/searchControls.scss
+++ b/src/views/search/controls/searchControls.scss
@@ -14,7 +14,3 @@
 .filtersBar {
   height: 34px;
 }
-
-.no-underline {
-  text-decoration: none;
-}

--- a/src/views/search/progressReport/ProgressReport.tsx
+++ b/src/views/search/progressReport/ProgressReport.tsx
@@ -1,0 +1,164 @@
+import { useState } from "react";
+import { BiCheck } from "react-icons/bi";
+import {
+  VuiFlexContainer,
+  VuiFlexItem,
+  VuiSpinner,
+  VuiIcon,
+  VuiText,
+  VuiTextColor,
+  VuiList,
+  VuiSpacer,
+  VuiAccordion,
+  VuiButtonSecondary,
+} from "../../../ui";
+import { DeserializedSearchResult } from "../types";
+
+type Props = {
+  isSearching: boolean;
+  isSummarizing: boolean;
+  searchResults?: DeserializedSearchResult[];
+};
+
+export const ProgressReport = ({
+  isSearching,
+  isSummarizing,
+  searchResults,
+}: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const receivedQuestionStep = {
+    key: "receivedQuestionStep",
+    isComplete: true,
+    render: () => (
+      <VuiFlexContainer alignItems="start" spacing="xs">
+        <VuiFlexItem>
+          <VuiIcon size="s" color="success">
+            <BiCheck />
+          </VuiIcon>
+        </VuiFlexItem>
+
+        <VuiFlexItem grow={false}>
+          <VuiText>
+            <p>Received question</p>
+          </VuiText>
+        </VuiFlexItem>
+      </VuiFlexContainer>
+    ),
+  };
+
+  const retrievingSearchResultsStep = {
+    key: "retrievingSearchResultsStep",
+    isComplete: true,
+    render: () => (
+      <VuiFlexContainer alignItems="start" spacing="xs">
+        <VuiFlexItem>
+          <VuiSpinner size="s" />
+        </VuiFlexItem>
+
+        <VuiFlexItem grow={false}>
+          <VuiText>
+            <p>Retrieving search results</p>
+          </VuiText>
+        </VuiFlexItem>
+      </VuiFlexContainer>
+    ),
+  };
+
+  const retrievedSearchResultsStep = {
+    key: "retrievedSearchResultsStep",
+    isComplete: true,
+    render: () => (
+      <VuiFlexContainer alignItems="start" spacing="xs">
+        <VuiFlexItem>
+          <VuiIcon size="s" color="success">
+            <BiCheck />
+          </VuiIcon>
+        </VuiFlexItem>
+
+        <VuiFlexItem grow={false}>
+          <VuiText>
+            <p>Retrieved search results</p>
+          </VuiText>
+
+          <VuiSpacer size="xs" />
+
+          <VuiButtonSecondary size="s" color="primary">
+            Review results
+          </VuiButtonSecondary>
+        </VuiFlexItem>
+      </VuiFlexContainer>
+    ),
+  };
+
+  const generateSummaryStep = {
+    key: "generateSummaryStep",
+    isComplete: false,
+    render: () => (
+      <VuiText>
+        <p>
+          <VuiTextColor color="subdued">Generate summary</VuiTextColor>
+        </p>
+      </VuiText>
+    ),
+  };
+
+  const generatingSummaryStep = {
+    key: "generatingSummaryStep",
+    isComplete: true,
+    render: () => (
+      <VuiFlexContainer alignItems="start" spacing="xs">
+        <VuiFlexItem>
+          <VuiSpinner size="s" />
+        </VuiFlexItem>
+
+        <VuiFlexItem grow={false}>
+          <VuiText>
+            <p>Generating summary</p>
+          </VuiText>
+        </VuiFlexItem>
+      </VuiFlexContainer>
+    ),
+  };
+
+  const generatedSummaryStep = {
+    key: "generatedSummaryStep",
+    isComplete: true,
+    render: () => (
+      <VuiFlexContainer alignItems="start" spacing="xs">
+        <VuiFlexItem>
+          <VuiIcon size="s" color="success">
+            <BiCheck />
+          </VuiIcon>
+        </VuiFlexItem>
+
+        <VuiFlexItem grow={false}>
+          <VuiText>
+            <p>Generated summary</p>
+          </VuiText>
+        </VuiFlexItem>
+      </VuiFlexContainer>
+    ),
+  };
+
+  let items = [receivedQuestionStep];
+
+  if (isSearching) {
+    items = items.concat([retrievingSearchResultsStep, generateSummaryStep]);
+  } else if (isSummarizing) {
+    items = items.concat([retrievedSearchResultsStep, generatingSummaryStep]);
+  } else {
+    items = items.concat([retrievedSearchResultsStep, generatedSummaryStep]);
+  }
+
+  return (
+    <VuiAccordion
+      header="Progress report"
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+    >
+      <VuiSpacer size="s" />
+      <VuiList size="s" items={items} alignItems="start" />
+    </VuiAccordion>
+  );
+};

--- a/src/views/search/progressReport/ProgressReport.tsx
+++ b/src/views/search/progressReport/ProgressReport.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { BiCheck } from "react-icons/bi";
+import { BiCheck, BiDetail } from "react-icons/bi";
 import {
   VuiFlexContainer,
   VuiFlexItem,
@@ -13,6 +13,7 @@ import {
   VuiButtonSecondary,
 } from "../../../ui";
 import { DeserializedSearchResult } from "../types";
+import { SearchResultsDrawer } from "./SearchResultsDrawer";
 
 type Props = {
   isSearching: boolean;
@@ -26,6 +27,8 @@ export const ProgressReport = ({
   searchResults,
 }: Props) => {
   const [isOpen, setIsOpen] = useState(false);
+  const [isReviewSearchResultsOpen, setIsReviewSearchResultsOpen] =
+    useState(false);
 
   const receivedQuestionStep = {
     key: "receivedQuestionStep",
@@ -76,14 +79,23 @@ export const ProgressReport = ({
           </VuiIcon>
         </VuiFlexItem>
 
-        <VuiFlexItem grow={false}>
+        <VuiFlexItem grow={false} alignItems="start">
           <VuiText>
             <p>Retrieved search results</p>
           </VuiText>
 
           <VuiSpacer size="xs" />
 
-          <VuiButtonSecondary size="s" color="primary">
+          <VuiButtonSecondary
+            size="s"
+            color="primary"
+            onClick={() => setIsReviewSearchResultsOpen(true)}
+            icon={
+              <VuiIcon>
+                <BiDetail />
+              </VuiIcon>
+            }
+          >
             Review results
           </VuiButtonSecondary>
         </VuiFlexItem>
@@ -152,13 +164,20 @@ export const ProgressReport = ({
   }
 
   return (
-    <VuiAccordion
-      header="Progress report"
-      isOpen={isOpen}
-      setIsOpen={setIsOpen}
-    >
-      <VuiSpacer size="s" />
-      <VuiList size="s" items={items} alignItems="start" />
-    </VuiAccordion>
+    <>
+      <VuiAccordion
+        header="Progress report"
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+      >
+        <VuiSpacer size="s" />
+        <VuiList size="s" items={items} alignItems="start" />
+      </VuiAccordion>
+
+      <SearchResultsDrawer
+        isOpen={isReviewSearchResultsOpen}
+        onClose={() => setIsReviewSearchResultsOpen(false)}
+      />
+    </>
   );
 };

--- a/src/views/search/progressReport/ProgressReport.tsx
+++ b/src/views/search/progressReport/ProgressReport.tsx
@@ -12,20 +12,14 @@ import {
   VuiAccordion,
   VuiButtonSecondary,
 } from "../../../ui";
-import { DeserializedSearchResult } from "../types";
 import { SearchResultsDrawer } from "./SearchResultsDrawer";
 
 type Props = {
   isSearching: boolean;
   isSummarizing: boolean;
-  searchResults?: DeserializedSearchResult[];
 };
 
-export const ProgressReport = ({
-  isSearching,
-  isSummarizing,
-  searchResults,
-}: Props) => {
+export const ProgressReport = ({ isSearching, isSummarizing }: Props) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isReviewSearchResultsOpen, setIsReviewSearchResultsOpen] =
     useState(false);

--- a/src/views/search/progressReport/SearchResultsDrawer.tsx
+++ b/src/views/search/progressReport/SearchResultsDrawer.tsx
@@ -3,17 +3,29 @@ import {
   VuiDrawer,
   VuiFlexContainer,
   VuiFlexItem,
+  VuiHorizontalRule,
   VuiIcon,
+  VuiSearchResult,
+  VuiSpacer,
   VuiText,
+  VuiTextColor,
   VuiTitle,
+  truncateEnd,
+  truncateStart,
 } from "../../../ui";
+import { useSearchContext } from "../../../contexts/SearchContext";
+import "./searchResultsDrawer.scss";
 
 type Props = {
   isOpen: boolean;
   onClose: () => void;
 };
 
+const CONTEXT_MAX_LENGTH = 200;
+
 export const SearchResultsDrawer = ({ isOpen, onClose }: Props) => {
+  const { searchValue, searchResults } = useSearchContext();
+
   return (
     <VuiDrawer
       isOpen={isOpen}
@@ -38,12 +50,64 @@ export const SearchResultsDrawer = ({ isOpen, onClose }: Props) => {
         </VuiFlexContainer>
       }
     >
+      <VuiText size="l">
+        <p>{searchValue}</p>
+      </VuiText>
+
+      <VuiSpacer size="xs" />
+
+      <VuiHorizontalRule />
+
+      <VuiSpacer size="m" />
+
       <VuiText>
         <p>
-          These are all of the search results retrieved for this query. Not all
-          of them will be used to generate a summary.
+          <VuiTextColor color="subdued">
+            These are all of the search results retrieved for this query. Not
+            all of them will be used to generate a summary.
+          </VuiTextColor>
         </p>
       </VuiText>
+
+      <VuiSpacer size="m" />
+
+      <div className="searchResultsDrawerResults">
+        {searchResults?.map((result, index) => {
+          const {
+            source,
+            title,
+            url,
+            snippet: { pre, post, text },
+          } = result;
+
+          return (
+            <VuiSearchResult
+              key={text}
+              result={{
+                title,
+                url,
+                snippet: {
+                  pre: truncateStart(pre, CONTEXT_MAX_LENGTH),
+                  text,
+                  post: truncateEnd(post, CONTEXT_MAX_LENGTH),
+                },
+              }}
+              position={index + 1}
+              subTitle={
+                <VuiText size="s">
+                  <p>
+                    <VuiTextColor color="subdued">
+                      Source: {source}
+                    </VuiTextColor>
+                  </p>
+                </VuiText>
+              }
+            />
+          );
+        })}
+      </div>
+
+      <VuiSpacer size="xl" />
     </VuiDrawer>
   );
 };

--- a/src/views/search/progressReport/SearchResultsDrawer.tsx
+++ b/src/views/search/progressReport/SearchResultsDrawer.tsx
@@ -1,0 +1,49 @@
+import { BiDetail } from "react-icons/bi";
+import {
+  VuiDrawer,
+  VuiFlexContainer,
+  VuiFlexItem,
+  VuiIcon,
+  VuiText,
+  VuiTitle,
+} from "../../../ui";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export const SearchResultsDrawer = ({ isOpen, onClose }: Props) => {
+  return (
+    <VuiDrawer
+      isOpen={isOpen}
+      onClose={onClose}
+      title={
+        <VuiFlexContainer
+          justifyContent="spaceBetween"
+          alignItems="center"
+          spacing="xs"
+        >
+          <VuiFlexItem>
+            <VuiIcon size="s">
+              <BiDetail />
+            </VuiIcon>
+          </VuiFlexItem>
+
+          <VuiFlexItem grow={1}>
+            <VuiTitle size="s">
+              <h2>Review search results</h2>
+            </VuiTitle>
+          </VuiFlexItem>
+        </VuiFlexContainer>
+      }
+    >
+      <VuiText>
+        <p>
+          These are all of the search results retrieved for this query. Not all
+          of them will be used to generate a summary.
+        </p>
+      </VuiText>
+    </VuiDrawer>
+  );
+};

--- a/src/views/search/progressReport/searchResultsDrawer.scss
+++ b/src/views/search/progressReport/searchResultsDrawer.scss
@@ -1,0 +1,5 @@
+@import "../../../ui/styleUtils/index";
+
+.searchResultsDrawerResults {
+  padding-left: $sizeXl;
+}


### PR DESCRIPTION
This PR introduces three changes to give users more visibility into the speed at which results load:
* I added options for selecting search more or summary mode so you can select the mode most relevant to the prospect’s use case
* I added a persistent progress report with more information, including information on how quickly each step completes when retrieving results and generating summaries
* The progress report surfaces a button the user can click to view all of the search results, even before the summary has been generated