### PR TITLE
Fix how "sources" works

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ If your application uses more than one corpus, you can define source filters to 
 # Hide or show source filters.
 enable_source_filters: True
 
+# whether the "all source" button should be enabled or not (default true)
+all_sources: True
+
 # A comma-separated list of the sources on which users can filter.
 sources: "BBC,NPR,FOX,CNBC,CNN"
 ```

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -24,6 +24,10 @@ else
     correct_path="$PWD/$1"
 fi
 docker run --platform=linux/amd64 -d  -v $correct_path/queries.json:/usr/src/app/build/queries.json  --env-file .env --name vanswer -p 127.0.0.1:80:3000/tcp vectara-answer
-echo "Success! Application is running at http://localhost:80.\nTo shut it down use: docker container stop vanswer."
-sleep 5
-open http://localhost
+if [ $? -eq 0 ]; then
+  echo "Success! Application is running at http://localhost:80.\nTo shut it down use: docker container stop vanswer."
+  sleep 5
+  open http://localhost
+else
+  echo "Container failed to start."
+fi

--- a/docker/server/index.js
+++ b/docker/server/index.js
@@ -56,6 +56,7 @@ app.post("/config", (req, res) => {
 
     // Filters
     enable_source_filters,
+    all_sources,
     sources,
 
     // Summary
@@ -115,6 +116,7 @@ app.post("/config", (req, res) => {
 
     // Filters
     enable_source_filters,
+    all_sources,
     sources,
 
     // summary

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vectara-answer",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vectara-answer",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "dependencies": {
         "@fullstory/browser": "^1.7.1",
         "@react-oauth/google": "^0.10.0",

--- a/server/index.js
+++ b/server/index.js
@@ -55,6 +55,7 @@ app.post("/config", (req, res) => {
 
     // Filters
     enable_source_filters,
+    all_sources,
     sources,
 
     // summary
@@ -114,6 +115,7 @@ app.post("/config", (req, res) => {
 
     // Filters
     enable_source_filters,
+    all_sources,
     sources,
 
     // summary

--- a/src/contexts/ConfigurationContext.tsx
+++ b/src/contexts/ConfigurationContext.tsx
@@ -36,6 +36,7 @@ interface Config {
 
   // Filters
   config_enable_source_filters?: string;
+  config_all_sources?: string;
   config_sources?: string;
 
   // Search header
@@ -106,6 +107,7 @@ type Source = { value: string; label: string };
 type Filters = {
   isEnabled: boolean;
   sources: Source[];
+  allSources: boolean;
   sourceValueToLabelMap?: Record<string, string>;
 };
 
@@ -236,6 +238,7 @@ export const ConfigContextProvider = ({ children }: Props) => {
   const [filters, setFilters] = useState<Filters>({
     isEnabled: false,
     sources: [],
+    allSources: true,
     sourceValueToLabelMap: {},
   });
   const [searchHeader, setSearchHeader] = useState<SearchHeader>({ logo: {} });
@@ -311,6 +314,7 @@ export const ConfigContextProvider = ({ children }: Props) => {
 
         // Filters
         config_enable_source_filters,
+        config_all_sources,
         config_sources,
 
         // App header
@@ -384,6 +388,7 @@ export const ConfigContextProvider = ({ children }: Props) => {
       });
 
       const isFilteringEnabled = isTrue(config_enable_source_filters);
+      const allSources = (config_all_sources === undefined) ? true : isTrue(config_all_sources);
 
       const sources =
         config_sources?.split(",").map((source) => ({
@@ -406,6 +411,7 @@ export const ConfigContextProvider = ({ children }: Props) => {
 
       setFilters({
         isEnabled: isFilteringEnabled,
+        allSources: allSources,
         sources,
         sourceValueToLabelMap,
       });

--- a/src/views/search/controls/SearchControls.tsx
+++ b/src/views/search/controls/SearchControls.tsx
@@ -24,7 +24,7 @@ type Props = {
 };
 
 export const SearchControls = ({ hasQuery }: Props) => {
-  const { filterValue, searchValue, setSearchValue, onSearch, reset } =
+  const { filterValue, setFilterValue, searchValue, setSearchValue, onSearch, reset } =
     useSearchContext();
   const { searchHeader, filters } = useConfigContext();
   const [isOptionsOpen, setIsOptionsOpen] = useState(false);
@@ -42,10 +42,16 @@ export const SearchControls = ({ hasQuery }: Props) => {
   const filterOptions: Array<{ value: string; text: string }> = [];
 
   if (filters.isEnabled) {
-    filterOptions.push({
-      text: "All sources",
-      value: "",
-    });
+    if (filters.allSources) {
+      filterOptions.push({
+        text: "All sources",
+        value: "",
+      });
+    }
+
+    if (!filters.allSources && filterValue === "") {
+      setFilterValue(filters.sources[0].value)
+    }
 
     filters.sources.forEach(({ value, label }) => {
       filterOptions.push({ text: label, value });

--- a/src/views/search/controls/SearchControls.tsx
+++ b/src/views/search/controls/SearchControls.tsx
@@ -49,6 +49,8 @@ export const SearchControls = ({ hasQuery }: Props) => {
       });
     }
 
+    // if allSources is false, then we set the filterValue is set to the first source
+    // In this case the "All sources" button is not there, and the first source is selected by default
     if (!filters.allSources && filterValue === "") {
       setFilterValue(filters.sources[0].value)
     }


### PR DESCRIPTION
all_sources configuration determines whether to show the "all sources" button or not.
If it's not shown, then we just show a button per source.
Useful for Finsearch demo.