### PR TITLE
Ignore citations that don't correspond to search results

### DIFF
--- a/src/ui/components/grid/Grid.tsx
+++ b/src/ui/components/grid/Grid.tsx
@@ -9,14 +9,16 @@ type Props = {
   children?: React.ReactNode;
   columns?: Columns;
   spacing?: FlexSpacing;
+  className?: string;
 };
 
-export const VuiGrid = ({ children, columns = 2, spacing = "m", ...rest }: Props) => {
-  const classes = classNames("vuiGrid", `vuiGrid--${spacing}`, `vuiGrid--columns${columns}`);
+export const VuiGrid = ({ children, columns = 2, spacing = "m", className, ...rest }: Props) => {
+  const classes = classNames("vuiGridContainer", className);
+  const contentClasses = classNames("vuiGrid", `vuiGrid--${spacing}`, `vuiGrid--columns${columns}`);
 
   return (
-    <div className="vuiGridContainer" {...rest}>
-      <div className={classes}>{children}</div>
+    <div className={classes} {...rest}>
+      <div className={contentClasses}>{children}</div>
     </div>
   );
 };

--- a/src/ui/components/grid/_index.scss
+++ b/src/ui/components/grid/_index.scss
@@ -1,5 +1,6 @@
 .vuiGridContainer {
   container-type: inline-size;
+  width: 100%;
 }
 
 .vuiGrid {

--- a/src/ui/components/modal/_index.scss
+++ b/src/ui/components/modal/_index.scss
@@ -44,7 +44,7 @@ $modalWidth: 500px;
 }
 
 .vuiModalContent {
-  overflow-y: scroll;
+  overflow-y: auto;
   overscroll-behavior: contain;
 }
 

--- a/src/ui/components/summary/Summary.test.tsx
+++ b/src/ui/components/summary/Summary.test.tsx
@@ -180,44 +180,44 @@ With some **bold** [2][3] and _emphasized_ [2][3] test. Here is a [link](https:/
             >
               <div>
                 <h1
-                  id="summarycitation-reference1---heres-a-heading-1"
+                  id="summarycitation-reference1--heres-a-heading-1"
                 >
                   <button
                     class="vuiSummaryCitation"
                   >
                     1
                   </button>
-                    Here's a heading 1
+                   Here's a heading 1
                 </h1>
                 <h2
-                  id="summarycitation-reference1---heres-a-heading-2"
+                  id="summarycitation-reference1--heres-a-heading-2"
                 >
                   <button
                     class="vuiSummaryCitation"
                   >
                     1
                   </button>
-                    Here's a heading 2
+                   Here's a heading 2
                 </h2>
                 <h3
-                  id="summarycitation-reference1---heres-a-heading-3"
+                  id="summarycitation-reference1--heres-a-heading-3"
                 >
                   <button
                     class="vuiSummaryCitation"
                   >
                     1
                   </button>
-                    Here's a heading 3
+                   Here's a heading 3
                 </h3>
                 <h4
-                  id="summarycitation-reference1---heres-a-heading-4"
+                  id="summarycitation-reference1--heres-a-heading-4"
                 >
                   <button
                     class="vuiSummaryCitation"
                   >
                     1
                   </button>
-                    Here's a heading 4
+                   Here's a heading 4
                 </h4>
                 <p>
                   With some 
@@ -234,7 +234,7 @@ With some **bold** [2][3] and _emphasized_ [2][3] test. Here is a [link](https:/
                   >
                     3
                   </button>
-                    and 
+                   and 
                   <em>
                     emphasized
                   </em>
@@ -248,7 +248,7 @@ With some **bold** [2][3] and _emphasized_ [2][3] test. Here is a [link](https:/
                   >
                     3
                   </button>
-                    test. Here is a 
+                   test. Here is a 
                   <a
                     href="https://www.vectara.com"
                   >
@@ -264,11 +264,11 @@ With some **bold** [2][3] and _emphasized_ [2][3] test. Here is a [link](https:/
                   >
                     3
                   </button>
-                   .
+                  .
                 </p>
                 <ul>
                   <li>
-                    An  
+                    An 
                     <button
                       class="vuiSummaryCitation"
                     >
@@ -281,7 +281,7 @@ With some **bold** [2][3] and _emphasized_ [2][3] test. Here is a [link](https:/
                     </button>
                   </li>
                   <li>
-                    Unordered  
+                    Unordered 
                     <button
                       class="vuiSummaryCitation"
                     >
@@ -294,7 +294,7 @@ With some **bold** [2][3] and _emphasized_ [2][3] test. Here is a [link](https:/
                     </button>
                   </li>
                   <li>
-                    List  
+                    List 
                     <button
                       class="vuiSummaryCitation"
                     >
@@ -311,7 +311,7 @@ With some **bold** [2][3] and _emphasized_ [2][3] test. Here is a [link](https:/
                   start="1"
                 >
                   <li>
-                    An  
+                    An 
                     <button
                       class="vuiSummaryCitation"
                     >
@@ -324,7 +324,7 @@ With some **bold** [2][3] and _emphasized_ [2][3] test. Here is a [link](https:/
                     </button>
                   </li>
                   <li>
-                    Ordered  
+                    Ordered 
                     <button
                       class="vuiSummaryCitation"
                     >
@@ -337,7 +337,7 @@ With some **bold** [2][3] and _emphasized_ [2][3] test. Here is a [link](https:/
                     </button>
                   </li>
                   <li>
-                    List  
+                    List 
                     <button
                       class="vuiSummaryCitation"
                     >
@@ -367,7 +367,7 @@ With some **bold** [2][3] and _emphasized_ [2][3] test. Here is a [link](https:/
                         Header
                       </td>
                       <td>
-                        Title  
+                        Title 
                         <button
                           class="vuiSummaryCitation"
                         >
@@ -420,7 +420,7 @@ With some **bold** [2][3] and _emphasized_ [2][3] test. Here is a [link](https:/
                 >
                   1
                 </button>
-                  Beginning of summary.  
+                 Beginning of summary. 
                 <button
                   class="vuiSummaryCitation"
                 >
@@ -431,25 +431,25 @@ With some **bold** [2][3] and _emphasized_ [2][3] test. Here is a [link](https:/
                 >
                   3
                 </button>
-                  Multiple at beginning of sentence, and before comma  
+                 Multiple at beginning of sentence, and before comma 
                 <button
                   class="vuiSummaryCitation"
                 >
                   4
                 </button>
-                 , single at middle  
+                , single at middle 
                 <button
                   class="vuiSummaryCitation"
                 >
                   5
                 </button>
-                  of sentence. At end of sentence  
+                 of sentence. At end of sentence 
                 <button
                   class="vuiSummaryCitation"
                 >
                   6
                 </button>
-                 .
+                .
 
               </div>
             </div>
@@ -472,7 +472,7 @@ With some **bold** [2][3] and _emphasized_ [2][3] test. Here is a [link](https:/
               class="vuiText vuiText--m"
             >
               <p>
-                End of summary.  
+                End of summary. 
                 <button
                   class="vuiSummaryCitation"
                 >
@@ -499,7 +499,7 @@ With some **bold** [2][3] and _emphasized_ [2][3] test. Here is a [link](https:/
               class="vuiText vuiText--m"
             >
               <p>
-                Two citations  
+                Two citations 
                 <button
                   class="vuiSummaryCitation"
                 >
@@ -510,7 +510,7 @@ With some **bold** [2][3] and _emphasized_ [2][3] test. Here is a [link](https:/
                 >
                   2
                 </button>
-                  and seven citations  
+                 and seven citations 
                 <button
                   class="vuiSummaryCitation"
                 >
@@ -546,7 +546,7 @@ With some **bold** [2][3] and _emphasized_ [2][3] test. Here is a [link](https:/
                 >
                   7
                 </button>
-                 .
+                .
               </p>
             </div>
           </div>

--- a/src/ui/components/table/Table.tsx
+++ b/src/ui/components/table/Table.tsx
@@ -36,6 +36,7 @@ type Props<T> = {
   columns: Column<T>[];
   rows: T[];
   actions?: TableRowActionsProps<T>["actions"];
+  actionsTestIdProvider?: (row: T) => string;
   pagination?: Pagination | Pager;
   selection?: Selection<T>;
   search?: Search;
@@ -75,6 +76,7 @@ export const VuiTable = <T extends Row>({
   columns,
   rows,
   actions,
+  actionsTestIdProvider,
   pagination,
   selection,
   search,
@@ -195,6 +197,7 @@ export const VuiTable = <T extends Row>({
                     setRowBeingActedUpon(undefined);
                   }
                 }}
+                testId={actionsTestIdProvider?.(row) ?? undefined}
               />
             </td>
           )}

--- a/src/ui/components/table/TableRowActions.tsx
+++ b/src/ui/components/table/TableRowActions.tsx
@@ -11,22 +11,24 @@ export type Action<T> = {
   isDisabled?: (row: T) => boolean;
   onClick?: (row: T) => void;
   href?: (row: T) => string | undefined;
+  testId?: string;
 };
 
 export type Props<T> = {
   row: any;
   actions: Action<T>[];
   onToggle: (isSelected: boolean) => void;
+  testId?: string;
 };
 
-export const VuiTableRowActions = <T extends Row>({ row, actions, onToggle }: Props<T>) => {
+export const VuiTableRowActions = <T extends Row>({ row, actions, onToggle, testId }: Props<T>) => {
   const [isOpen, setIsOpen] = useState(false);
 
   // Filter out disabled actions.
   const actionOptions = actions.reduce((acc, action) => {
-    const { label, isDisabled, onClick, href } = action;
+    const { label, isDisabled, onClick, href, testId } = action;
     if (!isDisabled?.(row)) {
-      acc.push({ label, onClick, href: href?.(row), value: row });
+      acc.push({ label, onClick, href: href?.(row), value: row, testId });
     }
     return acc;
   }, [] as any);
@@ -51,6 +53,7 @@ export const VuiTableRowActions = <T extends Row>({ row, actions, onToggle }: Pr
               <BiCaretDown />
             </VuiIcon>
           }
+          data-testid={testId}
         />
       }
     >

--- a/src/ui/utils/citations/applyCitationOrder.test.ts
+++ b/src/ui/utils/citations/applyCitationOrder.test.ts
@@ -69,4 +69,13 @@ describe("applyCitationOrder", () => {
       )
     ).toEqual([searchResult4, searchResult1, searchResult3]);
   });
+
+  test("ignores citations that are out of range of search results", () => {
+    expect(
+      applyCitationOrder(
+        [searchResult1, searchResult2, searchResult3, searchResult4],
+        "summary [5] some words [1][3] and stuff at the end"
+      )
+    ).toEqual([searchResult1, searchResult3]);
+  });
 });

--- a/src/ui/utils/citations/applyCitationOrder.ts
+++ b/src/ui/utils/citations/applyCitationOrder.ts
@@ -3,16 +3,23 @@ export const applyCitationOrder = (
   unorderedSummary: string
 ) => {
   const orderedSearchResults: any[] = [];
-  const allCitations = unorderedSummary.match(/\[\d+\]/g) || [];
+  const citations = unorderedSummary.match(/\[\d+\]/g) || [];
+  const addedCitations = new Set<string>();
 
-  const addedIndices = new Set<number>();
-  for (let i = 0; i < allCitations.length; i++) {
-    const citation = allCitations[i];
-    const index = Number(citation.slice(1, citation.length - 1)) - 1;
+  for (let i = 0; i < citations.length; i++) {
+    const citation = citations[i];
 
-    if (addedIndices.has(index)) continue;
-    orderedSearchResults.push(searchResults[index]);
-    addedIndices.add(index);
+    // Ignore citations that have already been added.
+    if (addedCitations.has(citation)) continue;
+
+    // Extract index from [INDEX] format.
+    const citationIndex = Number(citation.slice(1, citation.length - 1)) - 1;
+
+    // Ignore citations that are out of range of the search results.
+    if (citationIndex < 0 || citationIndex >= searchResults.length) continue;
+
+    orderedSearchResults.push(searchResults[citationIndex]);
+    addedCitations.add(citation);
   }
 
   return orderedSearchResults;

--- a/src/ui/utils/citations/applyCitationOrder.ts
+++ b/src/ui/utils/citations/applyCitationOrder.ts
@@ -6,11 +6,13 @@ export const applyCitationOrder = (
   const allCitations = unorderedSummary.match(/\[\d+\]/g) || [];
 
   const addedIndices = new Set<number>();
+
   for (let i = 0; i < allCitations.length; i++) {
     const citation = allCitations[i];
     const index = Number(citation.slice(1, citation.length - 1)) - 1;
 
     if (addedIndices.has(index)) continue;
+    if (index < 0 || index >= searchResults.length) continue;
     orderedSearchResults.push(searchResults[index]);
     addedIndices.add(index);
   }

--- a/src/ui/utils/citations/applyCitationOrder.ts
+++ b/src/ui/utils/citations/applyCitationOrder.ts
@@ -6,13 +6,11 @@ export const applyCitationOrder = (
   const allCitations = unorderedSummary.match(/\[\d+\]/g) || [];
 
   const addedIndices = new Set<number>();
-
   for (let i = 0; i < allCitations.length; i++) {
     const citation = allCitations[i];
     const index = Number(citation.slice(1, citation.length - 1)) - 1;
 
     if (addedIndices.has(index)) continue;
-    if (index < 0 || index >= searchResults.length) continue;
     orderedSearchResults.push(searchResults[index]);
     addedIndices.add(index);
   }

--- a/src/utils/deserializeSearchResponse.ts
+++ b/src/utils/deserializeSearchResponse.ts
@@ -12,7 +12,7 @@ const convertMetadataToObject = (metadata: DocMetadata[]) => {
 const parseMetadata = (rawMetadata: DocMetadata[]) => {
   const metadata = convertMetadataToObject(rawMetadata);
   return {
-    source: metadata.source as string || "unknown_source",
+    source: metadata.source,
     url: metadata.url,
     title: metadata.title || "Untitled",
     metadata

--- a/src/utils/deserializeSearchResponse.ts
+++ b/src/utils/deserializeSearchResponse.ts
@@ -12,7 +12,7 @@ const convertMetadataToObject = (metadata: DocMetadata[]) => {
 const parseMetadata = (rawMetadata: DocMetadata[]) => {
   const metadata = convertMetadataToObject(rawMetadata);
   return {
-    source: metadata.source,
+    source: metadata.source as string,
     url: metadata.url,
     title: metadata.title || "Untitled",
     metadata

--- a/src/utils/deserializeSearchResponse.ts
+++ b/src/utils/deserializeSearchResponse.ts
@@ -12,7 +12,7 @@ const convertMetadataToObject = (metadata: DocMetadata[]) => {
 const parseMetadata = (rawMetadata: DocMetadata[]) => {
   const metadata = convertMetadataToObject(rawMetadata);
   return {
-    source: metadata.source as string,
+    source: metadata.source as string || "unknown_source",
     url: metadata.url,
     title: metadata.title || "Untitled",
     metadata

--- a/src/views/search/SummaryUx.tsx
+++ b/src/views/search/SummaryUx.tsx
@@ -36,6 +36,9 @@ export const SummaryUx = () => {
         unorderedSummary
       );
     }
+    if (summarySearchResults.length === 0) {
+      summary = unorderedSummary.replace(/\[\d+\]/g, '');
+    }
   }
 
   return (

--- a/src/views/search/SummaryUx.tsx
+++ b/src/views/search/SummaryUx.tsx
@@ -36,8 +36,12 @@ export const SummaryUx = () => {
         unorderedSummary
       );
     }
+
+    // If there aren't any search results, we can safely sanitize the
+    // summary of any source text citations that might might be contaminating
+    // it.
     if (summarySearchResults.length === 0) {
-      summary = unorderedSummary.replace(/\[\d+\]/g, '');
+      summary = unorderedSummary.replace(/\[\d+\]/g, "");
     }
   }
 
@@ -85,9 +89,10 @@ export const SummaryUx = () => {
               <SearchResultList
                 results={summarySearchResults}
                 selectedSearchResultPosition={selectedSearchResultPosition}
-                setSearchResultRef={(el: HTMLDivElement | null, index: number) =>
-                  (searchResultsRef.current[index] = el)
-                }
+                setSearchResultRef={(
+                  el: HTMLDivElement | null,
+                  index: number
+                ) => (searchResultsRef.current[index] = el)}
               />
             </>
           )}


### PR DESCRIPTION
A user reported randomly encountering this error after issuing a search request:

![image](https://github.com/vectara/vectara-answer/assets/1238659/9dfecb3d-f314-4079-aba2-f56ca509530a)

This is due to the text of the corpus itself containing citations, e.g. a text segment like "here is some text [2344]."

The user is using prompt v1.2.0 which includes these citations in the summary. The long-term solution is to use an improved prompt that will exclude these citations, but this PR introduces a short-term solution. This solution ignores citations that don't correspond to search results. Note that this isn't a fool-proof solution because the corpus text could still contain citations that collide with actual search results. Those citations won't result in the above error, but they will be erroneously linked to the actual search results.