### PR TITLE
Update to search description

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,11 @@ corpus_id: "123,234,345"
 These configuration parameters enable you to configure the look and feel of the search header, including the logo.
 
 ```yaml
-# Define the title to render next to the logo.
+# Define the title to render above the search bar (next to the logo if it exists)
 search_title: "Search your data"
 
 # Define the description to render opposite the logo and title.
+# Note that this description is rendered as markdown, to enable for example link to a website
 search_description: "Data that speaks for itself"
 
 # Define the placeholder text inside the search box.
@@ -297,6 +298,8 @@ To modify the request handlers, make changes to `/server/index.js`.
 By default, Vectara Answer runs locally on your machine using `npm run start`. There is also an option to use Vectara Answer with Docker, which also makes it easy to deploy Vectara Answer to a cloud environment.
 
 Please see these detailed [instructions](DOCKER.md) for more details on using Docker.
+
+Note: the latest release of Vectara Answer is hosted on [docker-hub](https://hub.docker.com/repository/docker/vectara/vectara-answer/general), so if you want to pull it locally (instead of building) you can always use that image.
 
 ## Author
 

--- a/src/views/search/controls/SearchControls.tsx
+++ b/src/views/search/controls/SearchControls.tsx
@@ -18,6 +18,7 @@ import { useSearchContext } from "../../../contexts/SearchContext";
 import "./searchControls.scss";
 import { HistoryDrawer } from "./HistoryDrawer";
 import { OptionsDrawer } from "./OptionsDrawer";
+import Markdown from "markdown-to-jsx";
 
 type Props = {
   hasQuery: boolean;
@@ -102,11 +103,14 @@ export const SearchControls = ({ hasQuery }: Props) => {
             <VuiFlexContainer alignItems="center" spacing="m">
               {searchHeader.description && (
                 <VuiFlexItem grow={false}>
-                  <VuiTitle size="xxs" align="right">
+                  <VuiTitle size="xs" align="right">
                     <VuiTextColor color="subdued">
-                      <h2 style={{ whiteSpace: "pre-line" }}>
-                        {searchHeader.description.replaceAll("\\n", "\n")}
-                      </h2>
+                      <Markdown
+                        children={searchHeader.description}
+                        options={{
+                          forceBlock: true,
+                        }}
+                      />
                     </VuiTextColor>
                   </VuiTitle>
                 </VuiFlexItem>


### PR DESCRIPTION
Making the "search_description" be a Markdown component to support a need in one demo to include LINK in that description.